### PR TITLE
define a sampling ratio of 1%

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -28,6 +28,7 @@ from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.sdk.trace.sampling import TraceIdRatioBased
 
 #
 import nhlhelpers
@@ -44,7 +45,13 @@ resource = Resource.create(
     }
 )
 
-tracer_provider = TracerProvider(resource=resource)
+# Set the sampling ratio (e.g., 1%)
+SAMPLE_RATIO = 0.01
+
+# Create TraceIdRatioBased sampler
+trace_sampler = TraceIdRatioBased(SAMPLE_RATIO)
+
+tracer_provider = TracerProvider(resource=resource, sampler=trace_sampler)
 cloud_trace_exporter = CloudTraceSpanExporter()
 tracer_provider.add_span_processor(
     # BatchSpanProcessor buffers spans and sends them in batches in a


### PR DESCRIPTION
Getting these errors:

```
One or more TimeSeries could not be written: One or more points were
written more frequently than the maximum sampling period configured for
the metric.:
generic_task{task_id:wtangy_1,namespace:wtangy_main,location:global,job:wtangy}
timeSeries[0,1]:
workload.googleapis.com/http.server.active_requests{http_host:wtangy.se,http_scheme:https,http_server_name:0.0.0.0,http_method:GET,http_flavor:1.1}"
```