### PR TITLE
deploy often to reload schedule

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -3,6 +3,8 @@ name: Testing WTANGY.SE
 on:
   pull_request:
     types: [opened, synchronize, closed]
+  schedule:
+    - cron: '10 4 */2 * *' # Every second day at 4:10 am to reload schedule
 
 jobs:
   build:


### PR DESCRIPTION
We load it on startup to improve memory usage.

To refresh we relied on old ones being killed but they aren't much anymore.

Weekly is too rarely - the schedule is usually updated several times a week